### PR TITLE
feat: route-level code splitting and vendor chunking

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,3 +14,12 @@ body {
   margin: 0 auto;
   padding: var(--spacing-md);
 }
+
+.loading-screen {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  font-size: 1.2rem;
+  color: var(--color-text-secondary, #999);
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,27 +1,31 @@
+import { lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { AuthProvider } from './context/AuthContext'
 import ErrorBoundary from './components/ErrorBoundary'
-import Home from './pages/Home'
-import Join from './pages/Join'
-import Ballot from './pages/Ballot'
-import Leaderboard from './pages/Leaderboard'
-import Categories from './pages/Categories'
-import You from './pages/You'
 import './App.css'
+
+const Home = lazy(() => import('./pages/Home'))
+const Join = lazy(() => import('./pages/Join'))
+const Ballot = lazy(() => import('./pages/Ballot'))
+const Leaderboard = lazy(() => import('./pages/Leaderboard'))
+const Categories = lazy(() => import('./pages/Categories'))
+const You = lazy(() => import('./pages/You'))
 
 export default function App() {
   return (
     <BrowserRouter>
       <ErrorBoundary>
         <AuthProvider>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/:partyCode" element={<Join />} />
-            <Route path="/:partyCode/ballot" element={<Ballot />} />
-            <Route path="/:partyCode/leaderboard" element={<Leaderboard />} />
-            <Route path="/:partyCode/categories" element={<Categories />} />
-            <Route path="/:partyCode/you" element={<You />} />
-          </Routes>
+          <Suspense fallback={<div className="loading-screen">Loading…</div>}>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/:partyCode" element={<Join />} />
+              <Route path="/:partyCode/ballot" element={<Ballot />} />
+              <Route path="/:partyCode/leaderboard" element={<Leaderboard />} />
+              <Route path="/:partyCode/categories" element={<Categories />} />
+              <Route path="/:partyCode/you" element={<You />} />
+            </Routes>
+          </Suspense>
         </AuthProvider>
       </ErrorBoundary>
     </BrowserRouter>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,16 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          firebase: ['firebase/app', 'firebase/firestore', 'firebase/auth'],
+          react: ['react', 'react-dom', 'react-router-dom'],
+        },
+      },
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- Uses `React.lazy()` for all 6 page components with a `Suspense` fallback
- Splits Firebase and React/React-DOM into separate vendor chunks via Vite `manualChunks`
- Eliminates the 500KB+ single-chunk warning from `npm run build`
- Closes #17

## Bundle comparison

**Before** (single chunk):
```
dist/assets/index-BkjZsZ4W.js   610.49 kB │ gzip: 191.12 kB
⚠ Some chunks are larger than 500 kB after minification
```

**After** (code-split):
```
dist/assets/useParty-DtBbzhbJ.js        0.42 kB │ gzip:   0.30 kB
dist/assets/guests-BhRhAfj4.js          0.56 kB │ gzip:   0.38 kB
dist/assets/NavBar-CVEq7GFT.js          1.30 kB │ gzip:   0.56 kB
dist/assets/Join-0Tfi_T1v.js            1.40 kB │ gzip:   0.78 kB
dist/assets/categories-0XJlIrYW.js      1.74 kB │ gzip:   0.79 kB
dist/assets/You-Cf9SGUuj.js             2.05 kB │ gzip:   1.06 kB
dist/assets/Leaderboard-D9eBYdE7.js     2.08 kB │ gzip:   0.92 kB
dist/assets/Categories-DMuT9TNI.js      2.44 kB │ gzip:   0.98 kB
dist/assets/Ballot-C4FldII4.js          5.81 kB │ gzip:   2.10 kB
dist/assets/Home-CHaU7_o5.js           24.51 kB │ gzip:   8.73 kB
dist/assets/react-aupRaX7y.js          46.10 kB │ gzip:  16.32 kB
dist/assets/index-B7bms_Xt.js         185.90 kB │ gzip:  58.94 kB
dist/assets/firebase-Caqb1YgC.js      338.39 kB │ gzip: 104.80 kB
✓ No 500KB warning
```

Largest chunk dropped from **610 kB** to **338 kB** (Firebase vendor). Initial route chunk (`index`) is now **186 kB**. Page chunks are each under **25 kB**.

## Test plan
- [x] `npm run build` produces multiple chunks, no 500KB warning
- [x] `npx vitest run` — all 27 tests pass
- [x] `npm run lint` — no errors
- [ ] Manual test: app loads and navigates between routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)