### PR TITLE
fix: add CSP header and remove deprecated X-XSS-Protection

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -19,8 +19,8 @@
             "value": "strict-origin-when-cross-origin"
           },
           {
-            "key": "X-XSS-Protection",
-            "value": "1; mode=block"
+            "key": "Content-Security-Policy",
+            "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; img-src 'self' data:; frame-ancestors 'none'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Adds `Content-Security-Policy` header with directives for Firebase Firestore/Auth connectivity
- Removes deprecated `X-XSS-Protection` header (Chrome removed its XSS Auditor in 2019)
- CSP `frame-ancestors 'none'` provides the modern equivalent of `X-Frame-Options: DENY`

Closes #27

## Test plan
- [ ] Verify `npm run lint` passes
- [ ] Verify `npx vitest run` passes
- [ ] After deploy, check browser console for CSP violations
- [ ] Confirm Firebase Firestore real-time listeners still work (covered by connect-src whitelist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)