### PR TITLE
feat: expand guest ID range from 3-digit to 4-digit

### DIFF
--- a/src/firebase/guests.js
+++ b/src/firebase/guests.js
@@ -4,7 +4,7 @@ import { db } from './config'
 const MAX_RETRIES = 10
 
 function generateGuestId() {
-  return String(Math.floor(Math.random() * 900) + 100)
+  return String(Math.floor(Math.random() * 9000) + 1000)
 }
 
 export async function joinParty(partyCode, displayName, isHost = false) {


### PR DESCRIPTION
## Summary
- Expands `generateGuestId()` range from 100-999 (900 values) to 1000-9999 (9000 values)
- Reduces collision probability: at 50 guests, collision chance drops from ~5.6% to ~0.6% per attempt
- Existing 3-digit guest IDs remain valid — no migration needed

Closes #31

## Test plan
- [ ] Verify `npm run lint` passes
- [ ] Verify `npx vitest run` passes
- [ ] New guests joining a party get 4-digit IDs
- [ ] Existing parties with 3-digit guest IDs continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)