### PR TITLE
fix: add error handling to HostModeToggle Firestore write

### DIFF
--- a/src/components/HostModeToggle.jsx
+++ b/src/components/HostModeToggle.jsx
@@ -15,13 +15,18 @@ export default function HostModeToggle({ partyCode, onActivate }) {
     e.preventDefault()
     const hashedInput = await hashPin(pin)
     if (hashedInput === party?.hostPinHash) {
-      const stored = JSON.parse(localStorage.getItem(`guest_${partyCode}`) || '{}')
-      const guestRef = doc(db, 'parties', partyCode, 'guests', stored.guestId)
-      await updateDoc(guestRef, { isHost: true })
-      stored.isHost = true
-      localStorage.setItem(`guest_${partyCode}`, JSON.stringify(stored))
-      onActivate()
-      setShowPrompt(false)
+      try {
+        const stored = JSON.parse(localStorage.getItem(`guest_${partyCode}`) || '{}')
+        const guestRef = doc(db, 'parties', partyCode, 'guests', stored.guestId)
+        await updateDoc(guestRef, { isHost: true })
+        stored.isHost = true
+        localStorage.setItem(`guest_${partyCode}`, JSON.stringify(stored))
+        onActivate()
+        setShowPrompt(false)
+      } catch (err) {
+        console.error('Failed to activate host mode:', err)
+        setError('Could not activate host mode. Please try again.')
+      }
     } else {
       setError('Incorrect PIN')
     }

--- a/src/components/__tests__/HostModeToggle.test.jsx
+++ b/src/components/__tests__/HostModeToggle.test.jsx
@@ -96,4 +96,26 @@ describe('HostModeToggle', () => {
     render(<HostModeToggle partyCode="ABC123" onActivate={mockOnActivate} />)
     expect(screen.getByText('Host Mode')).toHaveClass('host-mode-link')
   })
+
+  it('shows error message when Firestore write fails', async () => {
+    updateDoc.mockRejectedValueOnce(new Error('Firestore unavailable'))
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<HostModeToggle partyCode="ABC123" onActivate={mockOnActivate} />)
+    fireEvent.click(screen.getByText('Host Mode'))
+    fireEvent.change(screen.getByPlaceholderText('Enter host PIN'), { target: { value: '1234' } })
+    fireEvent.submit(screen.getByText('Activate').closest('form'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not activate host mode. Please try again.')).toBeInTheDocument()
+    })
+    expect(mockOnActivate).not.toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to activate host mode:', expect.any(Error))
+
+    // Verify localStorage was not updated with isHost
+    const stored = JSON.parse(localStorage.getItem('guest_ABC123'))
+    expect(stored.isHost).toBeUndefined()
+
+    consoleSpy.mockRestore()
+  })
 })


### PR DESCRIPTION
## Summary
- Wraps the `updateDoc()` call in `HostModeToggle.handleSubmit` with try/catch
- Displays user-facing error message on Firestore write failure
- Prevents white-screen crash from unhandled promise rejection
- Aligns with error handling pattern used in Ballot.jsx and Join.jsx

Closes #26

## Test plan
- [ ] Verify `npm run lint` passes
- [ ] Verify `npx vitest run` passes
- [ ] Activate host mode successfully — behavior unchanged
- [ ] Simulate network error — error message shown, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)