### PR TITLE
fix: use password input type for host PIN entry

### DIFF
--- a/src/components/HostModeToggle.jsx
+++ b/src/components/HostModeToggle.jsx
@@ -37,7 +37,8 @@ export default function HostModeToggle({ partyCode, onActivate }) {
       <div className="host-prompt">
         <form onSubmit={handleSubmit}>
           <input
-            type="text"
+            type="password"
+            autoComplete="off"
             value={pin}
             onChange={(e) => { setPin(e.target.value); setError('') }}
             placeholder="Enter host PIN"


### PR DESCRIPTION
## Summary
- Changes host PIN input from `type="text"` to `type="password"` in HostModeToggle
- Adds `autoComplete="off"` to prevent browser password manager popups
- Prevents shoulder surfing of the host PIN during the party

Closes #30

## Test plan
- [ ] Verify `npm run lint` passes
- [ ] Verify `npx vitest run` passes
- [ ] PIN characters are masked when typing in host mode activation
- [ ] Browser does not offer to save/autofill the PIN

🤖 Generated with [Claude Code](https://claude.com/claude-code)