### PR TITLE
fix: add form labels, ARIA attributes, and keyboard support

### DIFF
--- a/src/components/CategoryCard.jsx
+++ b/src/components/CategoryCard.jsx
@@ -35,7 +35,14 @@ export default function CategoryCard({ category, myVote, onVote, onClearVote, is
 
   return (
     <div className={`category-card ${locked ? 'locked' : ''} ${winnerId ? 'announced' : ''}`}>
-      <div className="category-header" onClick={onToggleExpand}>
+      <div
+        className="category-header"
+        onClick={onToggleExpand}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggleExpand(); } }}
+        aria-expanded={expanded}
+      >
         <div className="header-left">
           <h3 className={isCorrect ? 'vote-correct' : isIncorrect ? 'vote-incorrect' : ''}>{locked && '\u{1F512} '}{statusIcon}{name}</h3>
           {renderCollapsedSummary()}
@@ -63,7 +70,7 @@ export default function CategoryCard({ category, myVote, onVote, onClearVote, is
         </div>
       </div>
       {expanded && (
-        <ul className="nominee-list">
+        <ul className="nominee-list" role="listbox" aria-label={name}>
           {nominees.map((nominee) => (
             <li
               key={nominee.id}
@@ -77,6 +84,17 @@ export default function CategoryCard({ category, myVote, onVote, onClearVote, is
                 if (locked) return
                 if (myVote === nominee.id) onClearVote(category.id)
                 else onVote(category.id, nominee.id)
+              }}
+              role="option"
+              tabIndex={locked ? -1 : 0}
+              aria-selected={myVote === nominee.id}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  if (locked) return
+                  if (myVote === nominee.id) onClearVote(category.id)
+                  else onVote(category.id, nominee.id)
+                }
               }}
             >
               <span className="nominee-name">{nominee.name}</span>

--- a/src/components/HostModeToggle.css
+++ b/src/components/HostModeToggle.css
@@ -20,6 +20,15 @@
   gap: var(--spacing-sm);
 }
 
+.host-prompt label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  font-weight: 600;
+  gap: var(--spacing-xs);
+  flex: 1;
+}
+
 .host-prompt input {
   flex: 1;
   padding: var(--spacing-xs) var(--spacing-sm);

--- a/src/components/HostModeToggle.jsx
+++ b/src/components/HostModeToggle.jsx
@@ -36,14 +36,17 @@ export default function HostModeToggle({ partyCode, onActivate }) {
     return (
       <div className="host-prompt">
         <form onSubmit={handleSubmit}>
-          <input
-            type="password"
-            autoComplete="off"
-            value={pin}
-            onChange={(e) => { setPin(e.target.value); setError('') }}
-            placeholder="Enter host PIN"
-            autoFocus
-          />
+          <label>
+            Host PIN
+            <input
+              type="password"
+              autoComplete="off"
+              value={pin}
+              onChange={(e) => { setPin(e.target.value); setError('') }}
+              placeholder="Enter host PIN"
+              autoFocus
+            />
+          </label>
           <button type="submit">Activate</button>
           <button type="button" onClick={() => setShowPrompt(false)}>Cancel</button>
         </form>

--- a/src/pages/Join.css
+++ b/src/pages/Join.css
@@ -18,6 +18,15 @@
   gap: var(--spacing-md);
 }
 
+.join label {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  font-size: 14px;
+  font-weight: 600;
+  gap: var(--spacing-xs);
+}
+
 .join input {
   padding: var(--spacing-sm) var(--spacing-md);
   border: 1px solid var(--color-border);

--- a/src/pages/Join.jsx
+++ b/src/pages/Join.jsx
@@ -51,15 +51,18 @@ export default function Join() {
       <h1>{party.name}</h1>
       <p>Enter your name to join the party and start voting!</p>
       <form onSubmit={handleJoin}>
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Your name"
-          maxLength={30}
-          required
-          autoFocus
-        />
+        <label>
+          Your Name
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Your name"
+            maxLength={30}
+            required
+            autoFocus
+          />
+        </label>
         <button type="submit" disabled={joining}>
           {joining ? 'Joining...' : 'Join Party'}
         </button>

--- a/src/pages/You.css
+++ b/src/pages/You.css
@@ -30,6 +30,15 @@
   gap: var(--spacing-sm);
 }
 
+.name-form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  font-weight: 600;
+  gap: var(--spacing-xs);
+  flex: 1;
+}
+
 .name-error {
   color: var(--color-error);
   font-size: 13px;

--- a/src/pages/You.jsx
+++ b/src/pages/You.jsx
@@ -55,13 +55,16 @@ export default function You() {
       <div className="you-card">
         <div className="guest-id-label">Guest #{guestId}</div>
         <form className="name-form" onSubmit={handleSaveName}>
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Your name"
-            maxLength={30}
-          />
+          <label>
+            Your Name
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name"
+              maxLength={30}
+            />
+          </label>
           <button
             type="submit"
             className="btn-small"


### PR DESCRIPTION
## Summary
- Adds `<label>` elements to form inputs in Join.jsx, You.jsx, and HostModeToggle.jsx
- Adds `role="button"`, `tabIndex`, `aria-expanded`, and keyboard handler to CategoryCard header
- Adds `role="option"`, `tabIndex`, `aria-selected`, and keyboard handler to nominee list items
- Adds `role="listbox"` with `aria-label` to the nominee list container
- Adds corresponding label CSS styles to Join.css, You.css, and HostModeToggle.css
- Makes the Ballot page fully navigable via keyboard and screen reader

Closes #28

## Test plan
- [ ] Verify `npm run lint` passes
- [ ] Verify `npx vitest run` passes
- [ ] Tab through Ballot page — all categories and nominees are focusable
- [ ] Press Enter/Space on category header — expands/collapses
- [ ] Press Enter/Space on nominee — casts vote
- [ ] Screen reader announces form labels and nominee selection state

🤖 Generated with [Claude Code](https://claude.com/claude-code)