### PR TITLE
fix: add salt to PIN hashing and validate vote document fields

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -54,8 +54,14 @@ service cloud.firestore {
         // Anyone can read votes
         allow read: if true;
 
-        // Anyone can cast or change a vote (no auth required)
-        allow create, update: if true;
+        // Anyone can cast or change a vote (no auth required), but
+        // documents must have the expected fields and the document ID
+        // must match the {guestId}_{categoryId} composite key.
+        allow create, update: if request.resource.data.keys().hasAll(['guestId', 'categoryId', 'nomineeId', 'timestamp'])
+                              && request.resource.data.guestId is string
+                              && request.resource.data.categoryId is string
+                              && request.resource.data.nomineeId is string
+                              && voteId == (request.resource.data.guestId + '_' + request.resource.data.categoryId);
       }
     }
 

--- a/src/components/HostModeToggle.jsx
+++ b/src/components/HostModeToggle.jsx
@@ -13,7 +13,7 @@ export default function HostModeToggle({ partyCode, onActivate }) {
 
   async function handleSubmit(e) {
     e.preventDefault()
-    const hashedInput = await hashPin(pin)
+    const hashedInput = await hashPin(pin, partyCode)
     if (hashedInput === party?.hostPinHash) {
       try {
         const stored = JSON.parse(localStorage.getItem(`guest_${partyCode}`) || '{}')

--- a/src/firebase/__tests__/parties.test.js
+++ b/src/firebase/__tests__/parties.test.js
@@ -76,6 +76,25 @@ describe('parties', () => {
     expect(hash1).not.toBe(hash2)
   })
 
+  it('hashPin with salt produces a different hash than without salt', async () => {
+    const unsalted = await hashPin('1234')
+    const salted = await hashPin('1234', 'ABC123')
+    expect(unsalted).not.toBe(salted)
+    expect(salted).toHaveLength(64)
+  })
+
+  it('hashPin with same salt is consistent', async () => {
+    const hash1 = await hashPin('1234', 'ABC123')
+    const hash2 = await hashPin('1234', 'ABC123')
+    expect(hash1).toBe(hash2)
+  })
+
+  it('hashPin with different salts produces different hashes', async () => {
+    const hash1 = await hashPin('1234', 'ABC123')
+    const hash2 = await hashPin('1234', 'XYZ789')
+    expect(hash1).not.toBe(hash2)
+  })
+
   it('getParty fetches a party by code', async () => {
     getDoc.mockResolvedValue({
       exists: () => true,

--- a/src/firebase/parties.js
+++ b/src/firebase/parties.js
@@ -10,9 +10,11 @@ function generatePartyCode() {
   return code
 }
 
-export async function hashPin(pin) {
+// Salt prevents rainbow-table attacks across parties.
+// Breaking change: existing (unsalted) hashes will no longer match — acceptable pre-launch.
+export async function hashPin(pin, salt = '') {
   const encoder = new TextEncoder()
-  const data = encoder.encode(pin)
+  const data = encoder.encode(salt + pin)
   const hashBuffer = await crypto.subtle.digest('SHA-256', data)
   const hashArray = Array.from(new Uint8Array(hashBuffer))
   return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
@@ -20,7 +22,6 @@ export async function hashPin(pin) {
 
 export async function createParty(name, hostPin, createdBy) {
   const maxAttempts = 3
-  const hostPinHash = await hashPin(hostPin)
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const partyCode = generatePartyCode()
@@ -28,6 +29,7 @@ export async function createParty(name, hostPin, createdBy) {
     const existing = await getDoc(partyRef)
 
     if (!existing.exists()) {
+      const hostPinHash = await hashPin(hostPin, partyCode)
       await setDoc(partyRef, {
         name,
         hostPinHash,


### PR DESCRIPTION
## Summary
- Adds `partyCode` as salt to `hashPin()` — prevents cross-party rainbow table attacks
- Updates all `hashPin()` callers (Home.jsx for creation, HostModeToggle.jsx for verification)
- Adds Firestore rules validation for vote documents: required fields, type checks, and composite key match
- Does NOT restructure data model for hostPinHash (deferred to future issue)

**Breaking:** Existing party PIN hashes will not match the new salted hashes. Acceptable since the app is pre-launch.

Closes #29

## Test plan
- [ ] Verify `npm run lint` passes
- [ ] Verify `npx vitest run` passes
- [ ] Create a new party — PIN works correctly with salted hash
- [ ] Activate host mode — PIN verification works with salted hash
- [ ] Cast a vote — Firestore rules accept valid vote documents
- [ ] Malformed vote documents are rejected by Firestore rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)