### PR TITLE
Move score indicator inline with ballot title (sticky row)

### DIFF
--- a/src/pages/Ballot.css
+++ b/src/pages/Ballot.css
@@ -4,7 +4,7 @@
 }
 
 .ballot h1 {
-  margin-bottom: var(--spacing-md);
+  margin-bottom: 0;
 }
 
 .floating-menu {
@@ -21,8 +21,15 @@
   z-index: 100;
 }
 
-.floating-menu .score-indicator {
-  margin-left: auto;
+.ballot-title-row {
+  position: sticky;
+  top: 46px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--color-bg);
+  padding: var(--spacing-md) 0 var(--spacing-sm) 0;
+  z-index: 99;
 }
 
 .host-banner {

--- a/src/pages/Ballot.jsx
+++ b/src/pages/Ballot.jsx
@@ -152,9 +152,11 @@ export default function Ballot() {
             <button className="btn-small" onClick={handleUnlockAll}>Unlock All</button>
           </>
         )}
+      </div>
+      <div className="ballot-title-row">
+        <h1>Your Ballot</h1>
         <ScoreIndicator correct={myScore.correct} total={myScore.total} />
       </div>
-      <h1>Your Ballot</h1>
       {hostMode && (
         <div className="host-banner">
           <span>Host Mode</span>


### PR DESCRIPTION
## Summary
- Moved `<ScoreIndicator>` from the fixed toolbar into a new `.ballot-title-row` wrapper alongside the `<h1>Your Ballot</h1>` heading
- Title row uses `position: sticky` to pin below the toolbar on scroll, keeping the score always visible
- Removed the old `.floating-menu .score-indicator` margin-left rule

## Test plan
- [ ] Score indicator appears on the same line as "Your Ballot" (title left, score right)
- [ ] Scrolling down: title row sticks below the toolbar
- [ ] Toolbar buttons (Expand/Collapse All, Lock/Unlock All in host mode) still work
- [ ] Layout correct in both host mode and guest mode
- [ ] All 104 tests pass (`npx vitest run`)
- [ ] Build succeeds (`npm run build`)
- [ ] Lint clean (`npm run lint`)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)