### PR TITLE
feat: add copy invite link button to Ballot page

### DIFF
--- a/src/pages/Ballot.css
+++ b/src/pages/Ballot.css
@@ -45,6 +45,10 @@
   font-size: 14px;
 }
 
+.copy-invite-btn {
+  transition: background-color 0.2s ease;
+}
+
 .error-toast {
   position: fixed;
   bottom: 90px;

--- a/src/pages/Ballot.jsx
+++ b/src/pages/Ballot.jsx
@@ -22,11 +22,14 @@ export default function Ballot() {
   const [hostMode, setHostMode] = useState(isHost)
   const [expandedIds, setExpandedIds] = useState(new Set())
   const [error, setError] = useState(null)
+  const [copied, setCopied] = useState(false)
   const errorTimerRef = useRef(null)
+  const copiedTimerRef = useRef(null)
 
   useEffect(() => {
     return () => {
       if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
     }
   }, [])
 
@@ -34,6 +37,19 @@ export default function Ballot() {
     setError(message)
     if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
     errorTimerRef.current = setTimeout(() => setError(null), 3000)
+  }
+
+  async function handleCopyInviteLink() {
+    const inviteUrl = `${window.location.origin}/${partyCode}`
+    try {
+      await navigator.clipboard.writeText(inviteUrl)
+      setCopied(true)
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy invite link:', err)
+      showError('Could not copy link. Please try again.')
+    }
   }
 
   const myVotes = {}
@@ -146,6 +162,13 @@ export default function Ballot() {
       <div className="floating-menu">
         <button className="btn-small" onClick={expandAll}>Expand All</button>
         <button className="btn-small" onClick={collapseAll}>Collapse All</button>
+        <button
+          className="btn-small copy-invite-btn"
+          onClick={handleCopyInviteLink}
+          aria-label="Copy invite link to clipboard"
+        >
+          {copied ? 'Copied!' : 'Copy Invite Link'}
+        </button>
         {hostMode && (
           <>
             <button className="btn-small" onClick={handleLockAll}>Lock All</button>

--- a/src/pages/__tests__/Ballot.test.jsx
+++ b/src/pages/__tests__/Ballot.test.jsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => ({ partyCode: 'ABC123' }),
+  }
+})
+
+vi.mock('../../hooks/useCategories', () => ({
+  useCategories: vi.fn(() => ({
+    categories: [
+      { id: 'cat1', name: 'Best Picture', nominees: [], sortOrder: 1 },
+    ],
+    loading: false,
+  })),
+}))
+
+vi.mock('../../hooks/useVotes', () => ({
+  useVotes: vi.fn(() => ({ votes: [] })),
+}))
+
+vi.mock('../../firebase/votes', () => ({
+  castVote: vi.fn(),
+  clearVote: vi.fn(),
+}))
+
+vi.mock('../../firebase/categories', () => ({
+  lockCategory: vi.fn(),
+  unlockCategory: vi.fn(),
+  lockAllCategories: vi.fn(),
+  unlockAllCategories: vi.fn(),
+  selectWinner: vi.fn(),
+  clearWinner: vi.fn(),
+}))
+
+vi.mock('../../utils/scoring', () => ({
+  calculateScores: vi.fn(() => ({})),
+}))
+
+vi.mock('../../components/CategoryCard', () => ({
+  default: () => <div data-testid="category-card" />,
+}))
+
+vi.mock('../../components/NavBar', () => ({
+  default: () => <nav data-testid="navbar" />,
+}))
+
+vi.mock('../../components/HostModeToggle', () => ({
+  default: () => <div data-testid="host-mode-toggle" />,
+}))
+
+vi.mock('../../components/ScoreIndicator', () => ({
+  default: () => <span data-testid="score-indicator" />,
+}))
+
+import Ballot from '../Ballot'
+
+function renderBallot() {
+  return render(
+    <MemoryRouter>
+      <Ballot />
+    </MemoryRouter>
+  )
+}
+
+describe('Ballot - Copy Invite Link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    localStorage.clear()
+    localStorage.setItem('guest_ABC123', JSON.stringify({ guestId: '1000' }))
+
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn(() => Promise.resolve()),
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders the Copy Invite Link button in the floating menu', () => {
+    renderBallot()
+    const button = screen.getByRole('button', { name: /copy invite link/i })
+    expect(button).toBeInTheDocument()
+  })
+
+  it('has an aria-label for accessibility', () => {
+    renderBallot()
+    const button = screen.getByRole('button', { name: /copy invite link/i })
+    expect(button).toHaveAttribute('aria-label', 'Copy invite link to clipboard')
+  })
+
+  it('copies the correct URL to clipboard when clicked', async () => {
+    renderBallot()
+    const button = screen.getByRole('button', { name: /copy invite link/i })
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/ABC123`
+    )
+  })
+
+  it('copied URL contains no guest-specific data', async () => {
+    renderBallot()
+    const button = screen.getByRole('button', { name: /copy invite link/i })
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    const copiedUrl = navigator.clipboard.writeText.mock.calls[0][0]
+    expect(copiedUrl).not.toContain('1000') // no guestId
+    expect(copiedUrl).not.toContain('guest') // no guest param
+    expect(copiedUrl).toBe(`${window.location.origin}/ABC123`)
+  })
+
+  it('shows "Copied!" feedback after clicking', async () => {
+    renderBallot()
+    const button = screen.getByRole('button', { name: /copy invite link/i })
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    expect(screen.getByText('Copied!')).toBeInTheDocument()
+  })
+
+  it('auto-clears "Copied!" feedback after 2 seconds', async () => {
+    renderBallot()
+    const button = screen.getByRole('button', { name: /copy invite link/i })
+
+    await act(async () => {
+      fireEvent.click(button)
+    })
+
+    expect(screen.getByText('Copied!')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(screen.queryByText('Copied!')).not.toBeInTheDocument()
+  })
+
+  it('button is visible for all guests (not host-only)', () => {
+    // Render without host mode
+    localStorage.setItem('guest_ABC123', JSON.stringify({ guestId: '1000', isHost: false }))
+    renderBallot()
+    const button = screen.getByRole('button', { name: /copy invite link/i })
+    expect(button).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds "Copy Invite Link" button to Ballot page floating menu for all guests
- Uses Clipboard API with brief "Copied!" visual feedback (auto-clears after 2s)
- Includes `aria-label` for accessibility
- 7 new tests covering render, click-to-copy, feedback display, and auto-clear

Closes #40

## Test plan
- [x] Button renders in floating menu for all guests (not host-only)
- [x] Clicking copies correct URL (`${origin}/${partyCode}`) to clipboard
- [x] "Copied!" feedback appears and auto-clears after 2 seconds
- [x] Copied URL contains no guest-specific data
- [x] All 111 existing tests still pass
- [x] Build succeeds (`npm run build`)
- [x] Lint clean (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)