### PR TITLE
feat: enable host delegates via anonymous auth

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,12 +2,13 @@ rules_version = '2';
 
 // Oscars Party Voting App — Firestore Security Rules
 //
-// Auth-based rules (Issue #4). Firebase Auth is now integrated, so we
-// enforce server-side authorization for privileged operations:
+// Auth-based rules (Issue #4, updated by Issue #43).
+// Firebase Auth is integrated for privileged operations:
 //
 //   - Party creation: requires authenticated user; createdBy must match uid
 //   - Party updates: only the party creator (createdBy == auth.uid)
-//   - Category writes (lock/unlock/selectWinner): only the party creator
+//   - Category writes (lock/unlock/selectWinner): any authenticated user
+//     (host delegates sign in anonymously after PIN validation on the client)
 //   - Guest create/update: open (anyone can join and scores update from any client)
 //   - Votes create/update: open (anyone can vote without auth)
 //   - All reads: open (guests need to see everything)
@@ -33,10 +34,10 @@ service cloud.firestore {
         // Anyone can read categories
         allow read: if true;
 
-        // Only the party creator can write categories
+        // Any authenticated user can write categories
         // (lock/unlock, selectWinner, seeding)
-        allow write: if request.auth != null
-                     && request.auth.uid == get(/databases/$(database)/documents/parties/$(partyCode)).data.createdBy;
+        // Host delegates authenticate anonymously after PIN validation
+        allow write: if request.auth != null;
       }
 
       match /guests/{guestId} {

--- a/src/components/HostModeToggle.jsx
+++ b/src/components/HostModeToggle.jsx
@@ -3,6 +3,7 @@ import { useParty } from '../hooks/useParty'
 import { doc, updateDoc } from 'firebase/firestore'
 import { db } from '../firebase/config'
 import { hashPin } from '../firebase/parties'
+import { signInAnonymouslyIfNeeded } from '../firebase/auth'
 import './HostModeToggle.css'
 
 export default function HostModeToggle({ partyCode, onActivate }) {
@@ -16,6 +17,9 @@ export default function HostModeToggle({ partyCode, onActivate }) {
     const hashedInput = await hashPin(pin, partyCode)
     if (hashedInput === party?.hostPinHash) {
       try {
+        // Ensure delegate has Firebase Auth identity for Firestore security rules
+        await signInAnonymouslyIfNeeded()
+
         const stored = JSON.parse(localStorage.getItem(`guest_${partyCode}`) || '{}')
         const guestRef = doc(db, 'parties', partyCode, 'guests', stored.guestId)
         await updateDoc(guestRef, { isHost: true })

--- a/src/components/__tests__/HostModeToggle.test.jsx
+++ b/src/components/__tests__/HostModeToggle.test.jsx
@@ -20,8 +20,13 @@ vi.mock('../../firebase/parties', () => ({
   hashPin: vi.fn((pin) => Promise.resolve(pin === '1234' ? 'mock-hash' : 'wrong-hash')),
 }))
 
+vi.mock('../../firebase/auth', () => ({
+  signInAnonymouslyIfNeeded: vi.fn(() => Promise.resolve({ uid: 'anon-test-uid' })),
+}))
+
 import HostModeToggle from '../HostModeToggle'
 import { updateDoc } from 'firebase/firestore'
+import { signInAnonymouslyIfNeeded } from '../../firebase/auth'
 
 describe('HostModeToggle', () => {
   const mockOnActivate = vi.fn()
@@ -115,6 +120,50 @@ describe('HostModeToggle', () => {
     // Verify localStorage was not updated with isHost
     const stored = JSON.parse(localStorage.getItem('guest_ABC123'))
     expect(stored.isHost).toBeUndefined()
+
+    consoleSpy.mockRestore()
+  })
+
+  it('calls signInAnonymouslyIfNeeded on correct PIN before updating Firestore', async () => {
+    render(<HostModeToggle partyCode="ABC123" onActivate={mockOnActivate} />)
+    fireEvent.click(screen.getByText('Host Mode'))
+    fireEvent.change(screen.getByPlaceholderText('Enter host PIN'), { target: { value: '1234' } })
+    fireEvent.submit(screen.getByText('Activate').closest('form'))
+
+    await waitFor(() => {
+      expect(signInAnonymouslyIfNeeded).toHaveBeenCalled()
+      expect(updateDoc).toHaveBeenCalledWith('mock-doc-ref', { isHost: true })
+      expect(mockOnActivate).toHaveBeenCalled()
+    })
+  })
+
+  it('does not call signInAnonymouslyIfNeeded on incorrect PIN', async () => {
+    render(<HostModeToggle partyCode="ABC123" onActivate={mockOnActivate} />)
+    fireEvent.click(screen.getByText('Host Mode'))
+    fireEvent.change(screen.getByPlaceholderText('Enter host PIN'), { target: { value: '9999' } })
+    fireEvent.submit(screen.getByText('Activate').closest('form'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Incorrect PIN')).toBeInTheDocument()
+    })
+    expect(signInAnonymouslyIfNeeded).not.toHaveBeenCalled()
+  })
+
+  it('shows error message when anonymous sign-in fails', async () => {
+    signInAnonymouslyIfNeeded.mockRejectedValueOnce(new Error('Anonymous auth failed'))
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<HostModeToggle partyCode="ABC123" onActivate={mockOnActivate} />)
+    fireEvent.click(screen.getByText('Host Mode'))
+    fireEvent.change(screen.getByPlaceholderText('Enter host PIN'), { target: { value: '1234' } })
+    fireEvent.submit(screen.getByText('Activate').closest('form'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not activate host mode. Please try again.')).toBeInTheDocument()
+    })
+    expect(mockOnActivate).not.toHaveBeenCalled()
+    expect(updateDoc).not.toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to activate host mode:', expect.any(Error))
 
     consoleSpy.mockRestore()
   })

--- a/src/firebase/__tests__/auth.test.js
+++ b/src/firebase/__tests__/auth.test.js
@@ -4,14 +4,16 @@ vi.mock('firebase/auth', () => ({
   GoogleAuthProvider: vi.fn(),
   signInWithPopup: vi.fn(),
   signOut: vi.fn(),
+  signInAnonymously: vi.fn(),
 }))
 
 vi.mock('../config', () => ({
   auth: {},
 }))
 
-import { signInWithGoogle, signOutUser } from '../auth'
-import { GoogleAuthProvider, signInWithPopup, signOut } from 'firebase/auth'
+import { signInWithGoogle, signOutUser, signInAnonymouslyIfNeeded } from '../auth'
+import { GoogleAuthProvider, signInWithPopup, signOut, signInAnonymously } from 'firebase/auth'
+import { auth } from '../config'
 
 describe('auth', () => {
   beforeEach(() => {
@@ -30,5 +32,43 @@ describe('auth', () => {
     signOut.mockResolvedValue()
     await signOutUser()
     expect(signOut).toHaveBeenCalledWith({})
+  })
+
+  describe('signInAnonymouslyIfNeeded', () => {
+    it('calls signInAnonymously when no user is currently signed in', async () => {
+      auth.currentUser = null
+      const mockUser = { uid: 'anon-123', isAnonymous: true }
+      signInAnonymously.mockResolvedValue({ user: mockUser })
+
+      const user = await signInAnonymouslyIfNeeded()
+
+      expect(signInAnonymously).toHaveBeenCalledWith(auth)
+      expect(user).toEqual(mockUser)
+    })
+
+    it('skips signInAnonymously when user is already signed in with Google', async () => {
+      auth.currentUser = { uid: 'google-user-123', isAnonymous: false }
+
+      const user = await signInAnonymouslyIfNeeded()
+
+      expect(signInAnonymously).not.toHaveBeenCalled()
+      expect(user).toEqual({ uid: 'google-user-123', isAnonymous: false })
+    })
+
+    it('skips signInAnonymously when user is already signed in anonymously', async () => {
+      auth.currentUser = { uid: 'anon-456', isAnonymous: true }
+
+      const user = await signInAnonymouslyIfNeeded()
+
+      expect(signInAnonymously).not.toHaveBeenCalled()
+      expect(user).toEqual({ uid: 'anon-456', isAnonymous: true })
+    })
+
+    it('throws when anonymous sign-in fails', async () => {
+      auth.currentUser = null
+      signInAnonymously.mockRejectedValue(new Error('Auth service unavailable'))
+
+      await expect(signInAnonymouslyIfNeeded()).rejects.toThrow('Auth service unavailable')
+    })
   })
 })

--- a/src/firebase/auth.js
+++ b/src/firebase/auth.js
@@ -1,4 +1,4 @@
-import { GoogleAuthProvider, signInWithPopup, signOut } from 'firebase/auth'
+import { GoogleAuthProvider, signInWithPopup, signOut, signInAnonymously } from 'firebase/auth'
 import { auth } from './config'
 
 const provider = new GoogleAuthProvider()
@@ -10,4 +10,18 @@ export async function signInWithGoogle() {
 
 export async function signOutUser() {
   await signOut(auth)
+}
+
+/**
+ * Signs in anonymously if no user is currently authenticated.
+ * Used by host delegates who authenticate via PIN but need a Firebase Auth
+ * identity to satisfy Firestore security rules.
+ * Skips sign-in if the user is already authenticated (Google or anonymous).
+ */
+export async function signInAnonymouslyIfNeeded() {
+  if (auth.currentUser) {
+    return auth.currentUser
+  }
+  const result = await signInAnonymously(auth)
+  return result.user
 }


### PR DESCRIPTION
## Summary
- Relaxes Firestore category write rule from `createdBy == auth.uid` to `auth != null`
- Adds anonymous Firebase auth for PIN-authenticated delegates
- Skips auth if user already signed in (e.g., Google)
- Shows error message if anonymous sign-in fails

Closes #43

## Test plan
- [ ] Delegate with correct PIN can lock/unlock categories
- [ ] Delegate can lock all / unlock all
- [ ] Delegate can select and clear winners
- [ ] Original party creator retains full capabilities
- [ ] Guest without PIN does not see host controls
- [ ] Anonymous sign-in is called on PIN success
- [ ] Error shown if anonymous auth fails
- [ ] All existing tests pass
- [ ] Build and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)