### PR TITLE
fix: correct QR code URL on observer leaderboard

### DIFF
--- a/src/pages/ObserverLeaderboard.jsx
+++ b/src/pages/ObserverLeaderboard.jsx
@@ -49,7 +49,7 @@ export default function ObserverLeaderboard() {
         <div className="qr-section">
           <p className="qr-label">Scan to join</p>
           <QRCodeSVG
-            value={`${window.location.origin}/${partyCode}/join`}
+            value={`${window.location.origin}/${partyCode}`}
             size={160}
             bgColor="#ffffff"
             fgColor="#000000"

--- a/src/pages/__tests__/ObserverLeaderboard.test.jsx
+++ b/src/pages/__tests__/ObserverLeaderboard.test.jsx
@@ -56,6 +56,10 @@ vi.mock('../../utils/scoring', () => ({
   })),
 }))
 
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: (props) => <div data-testid="qr-code" data-value={props.value} />,
+}))
+
 import ObserverLeaderboard from '../ObserverLeaderboard'
 import { useParty } from '../../hooks/useParty'
 import { useGuests } from '../../hooks/useGuests'
@@ -172,5 +176,14 @@ describe('ObserverLeaderboard', () => {
     const { container } = renderObserver()
     expect(container.querySelector('.observer-leaderboard')).toBeInTheDocument()
     expect(container.querySelector('.leaderboard')).not.toBeInTheDocument()
+  })
+
+  it('renders QR code pointing to /:partyCode (not /:partyCode/join)', () => {
+    renderObserver()
+    const qr = screen.getByTestId('qr-code')
+    expect(qr).toBeInTheDocument()
+    const value = qr.getAttribute('data-value')
+    expect(value).toBe(`${window.location.origin}/ABC123`)
+    expect(value).not.toContain('/join')
   })
 })


### PR DESCRIPTION
## Summary
- Fixed the QR code on the observer leaderboard pointing to a nonexistent route (`/:partyCode/join` instead of `/:partyCode`), which caused a blank page when scanned
- Added a regression test that mocks `QRCodeSVG` and asserts the `value` prop does not contain `/join`

Fixes #54

## Test plan
- [x] All 131 existing tests pass
- [x] New test verifies QR code URL is `${origin}/${partyCode}` (no `/join` suffix)
- [x] ESLint passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)